### PR TITLE
Ensure bindMethods can bind methods all the way up a proto chain.

### DIFF
--- a/src/classes/base-component.jsx
+++ b/src/classes/base-component.jsx
@@ -19,7 +19,7 @@ import bindMethods from '../util/bind-methods';
 class BaseComponent extends React.Component {
   constructor(props) {
     super(props);
-    bindMethods(this);
+    bindMethods(this, BaseComponent);
   }
 }
 

--- a/src/util/bind-methods.js
+++ b/src/util/bind-methods.js
@@ -3,27 +3,47 @@
  * @module utilBindMethods
  */
 
+
+const isMethod = (obj, name) => typeof obj[name] === 'function';
+
+function walkProtoMethods(object, ctor) {
+  const proto = Object.getPrototypeOf(object);
+  if (!proto) {
+    return [];
+  }
+  if (proto === ctor.prototype) {
+    return Object.getOwnPropertyNames(proto).filter(isMethod.bind(null, proto));
+  }
+  return Object.getOwnPropertyNames(proto)
+    .filter(isMethod.bind(null, proto))
+    .concat(walkProtoMethods(proto, ctor));
+}
 /**
  * Auto-bind methods to the passed-in object
  * @alias bindMethods
  * @param {object} thisValue - The object to bind as method context
- * @param {array} [methodNames] - The list of methods to bind. Defaults to all.
+ * @param {array} [methodNames] - The list of methods to bind, or a parent constructor
+ *                              function. Will walk from thisValue to the parent
+ *                              constructor and retreive all methods.
  * @returns {void}
  */
-export default function(thisValue, methodNames) {
+export default function bindMethods(thisValue, methodNames) {
 
-  const protoObj = Object.getPrototypeOf(thisValue);
   let methods = methodNames;
+
+  if (typeof methods === 'function') {
+    methods = walkProtoMethods(thisValue, methods);
+  }
 
   // If we don't pass in an array of methods, set it to all own methods
   if (!methods) {
-    methods = Object.getOwnPropertyNames(protoObj).filter(
-      name => typeof protoObj[name] === 'function'
-    );
+    methods = walkProtoMethods(thisValue, Object);
   }
 
   // Bind the methods in the list
-  methods.forEach(name => {
-    thisValue[name] = protoObj[name].bind(thisValue);
-  });
+  methods
+    .filter(isMethod.bind(null, thisValue))
+    .forEach(name => {
+      thisValue[name] = thisValue[name].bind(thisValue);
+    });
 }


### PR DESCRIPTION
- Allow passing a parent constructor (default to Object) and walk
  up the thisValue's prototype chain until we get to the parent.
